### PR TITLE
Fix a webpack devtool that works without unsave-eval CSP

### DIFF
--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -8,5 +8,5 @@ module.exports = merge(common, {
 		noInfo: true,
 		overlay: true
 	},
-	devtool: '#eval-source-map',
+	devtool: 'source-map',
 })


### PR DESCRIPTION
This is required in order to `npm link` this package to other apps while `npm watch`'ing it.

Ref https://webpack.js.org/configuration/devtool/.