### PR TITLE
Multiselect style and manual scoping

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,7 +12,8 @@ module.exports = {
 		OC: true,
 		OCA: true,
 		Vue: true,
-		VueRouter: true
+		VueRouter: true,
+		SCOPE_VERSION: true
 	},
 	parserOptions: {
 		parser: 'babel-eslint',

--- a/src/components/AppNavigation/AppNavigationItem.vue
+++ b/src/components/AppNavigation/AppNavigationItem.vue
@@ -105,7 +105,7 @@
 </template>
 
 <script>
-import PopoverMenu from '../PopoverMenu/PopoverMenu'
+import PopoverMenu from 'Components/PopoverMenu/PopoverMenu'
 import ClickOutside from 'vue-click-outside'
 import Vue from 'vue'
 

--- a/src/components/Avatar/Avatar.vue
+++ b/src/components/Avatar/Avatar.vue
@@ -38,7 +38,7 @@
 /* global OC oc_userconfig */
 
 import { VTooltip } from 'v-tooltip'
-import { PopoverMenu } from '../PopoverMenu'
+import { PopoverMenu } from 'Components/PopoverMenu'
 import ClickOutside from 'vue-click-outside'
 import axios from 'nextcloud-axios'
 import uidToColor from './uidToColor'

--- a/src/components/Multiselect/index.js
+++ b/src/components/Multiselect/index.js
@@ -22,11 +22,10 @@
 import Multiselect from 'vue-multiselect'
 import './index.scss'
 
+// Manually force the addition of a scope data for the css
 Multiselect.mounted = [
 	function() {
-		console.debug(this, this.$el)
-		// eslint-disable-next-line
-		this.$el.className += ' ' + SCOPE_VERSION
+		this.$el.setAttribute(`data-v-${SCOPE_VERSION}`, '')
 	}
 ]
 

--- a/src/components/Multiselect/index.js
+++ b/src/components/Multiselect/index.js
@@ -22,5 +22,13 @@
 import Multiselect from 'vue-multiselect'
 import './index.scss'
 
+Multiselect.mounted = [
+	function() {
+		console.debug(this, this.$el)
+		// eslint-disable-next-line
+		this.$el.className += ' ' + SCOPE_VERSION
+	}
+]
+
 export default Multiselect
 export { Multiselect }

--- a/src/components/Multiselect/index.scss
+++ b/src/components/Multiselect/index.scss
@@ -1,4 +1,4 @@
-.multiselect {
+.multiselect[data-v-#{$scope_version}] {
 	margin: 1px 2px;
 	padding: 0 !important;
 	display: inline-block;

--- a/src/utils/ScopeComponent.js
+++ b/src/utils/ScopeComponent.js
@@ -19,11 +19,13 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  *
  */
-import ScopeComponent from 'Utils/ScopeComponent'
-import Multiselect from 'vue-multiselect'
-import './index.scss'
 
-ScopeComponent(Multiselect)
+const ScopeComponent = (Component) => {
+	Component.mounted = [
+		function() {
+			this.$el.setAttribute(`data-v-${SCOPE_VERSION}`, '')
+		}
+	]
+}
 
-export default Multiselect
-export { Multiselect }
+export default ScopeComponent

--- a/src/utils/ScopeElement.js
+++ b/src/utils/ScopeElement.js
@@ -23,13 +23,13 @@
 /**
  * Manually scope a vue component to be used with an external css file
  * The external css must have the root element set with [data-v-#{$scope_version}]
- * 
+ *
  * e.g. .multiselect[data-v-#{$scope_version}]
  * import ScopeComponent from 'Utils/ScopeComponent'
  * import Multiselect from 'vue-multiselect'
  * import './index.scss'
  * ScopeComponent(Multiselect)
- * 
+ *
  * @param {Object} Component the vue component
  */
 const ScopeComponent = (Component) => {

--- a/src/utils/ScopeElement.js
+++ b/src/utils/ScopeElement.js
@@ -1,0 +1,43 @@
+/**
+ * @copyright Copyright (c) 2018 John Molakvoæ <skjnldsv@protonmail.com>
+ *
+ * @author John Molakvoæ <skjnldsv@protonmail.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * Manually scope a vue component to be used with an external css file
+ * The external css must have the root element set with [data-v-#{$scope_version}]
+ * 
+ * e.g. .multiselect[data-v-#{$scope_version}]
+ * import ScopeComponent from 'Utils/ScopeComponent'
+ * import Multiselect from 'vue-multiselect'
+ * import './index.scss'
+ * ScopeComponent(Multiselect)
+ * 
+ * @param {Object} Component the vue component
+ */
+const ScopeComponent = (Component) => {
+	Component.mounted = [
+		function() {
+			this.$el.setAttribute(`data-v-${SCOPE_VERSION}`, '')
+		}
+	]
+}
+
+export default ScopeComponent

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -3,6 +3,7 @@ const { VueLoaderPlugin } = require('vue-loader')
 const StyleLintPlugin = require('stylelint-webpack-plugin')
 const { DefinePlugin } = require('webpack')
 
+// scope variable
 const md5 = require('md5')
 const PACKAGE = require('./package.json');
 const SCOPE_VERSION = JSON.stringify(md5(PACKAGE.version).substr(0, 7))
@@ -70,7 +71,8 @@ module.exports = {
 	],
 	resolve: {
 		alias: {
-			vue$: 'vue/dist/vue.esm.js'
+			Components: path.resolve(__dirname, 'src/components/'),
+			Utils: path.resolve(__dirname, 'src/utils/')
 		},
 		extensions: ['*', '.js', '.vue', '.json']
 	}

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -5,8 +5,7 @@ const { DefinePlugin } = require('webpack')
 
 const md5 = require('md5')
 const PACKAGE = require('./package.json');
-const version = PACKAGE.version;
-const SCOPE_VERSION = JSON.stringify(md5(version).substr(0, 7))
+const SCOPE_VERSION = JSON.stringify(md5(PACKAGE.version).substr(0, 7))
 
 module.exports = {
 	entry: path.join(__dirname, 'src', 'index.js'),

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -1,6 +1,10 @@
 const path = require('path')
 const { VueLoaderPlugin } = require('vue-loader')
 const StyleLintPlugin = require('stylelint-webpack-plugin')
+const { DefinePlugin } = require('webpack')
+const md5 = require('md5')
+var PACKAGE = require('./package.json');
+var version = PACKAGE.version;
 
 module.exports = {
 	entry: path.join(__dirname, 'src', 'index.js'),
@@ -53,7 +57,13 @@ module.exports = {
 			}
 		]
 	},
-	plugins: [new VueLoaderPlugin(), new StyleLintPlugin()],
+	plugins: [
+		new VueLoaderPlugin(),
+		new StyleLintPlugin(),
+		new DefinePlugin({
+			SCOPE_VERSION: JSON.stringify(md5(version))
+		})
+	],
 	resolve: {
 		alias: {
 			vue$: 'vue/dist/vue.esm.js'

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -2,9 +2,11 @@ const path = require('path')
 const { VueLoaderPlugin } = require('vue-loader')
 const StyleLintPlugin = require('stylelint-webpack-plugin')
 const { DefinePlugin } = require('webpack')
+
 const md5 = require('md5')
-var PACKAGE = require('./package.json');
-var version = PACKAGE.version;
+const PACKAGE = require('./package.json');
+const version = PACKAGE.version;
+const SCOPE_VERSION = JSON.stringify(md5(version).substr(0, 7))
 
 module.exports = {
 	entry: path.join(__dirname, 'src', 'index.js'),
@@ -32,7 +34,12 @@ module.exports = {
 			},
 			{
 				test: /\.scss$/,
-				use: ['vue-style-loader', 'css-loader', 'sass-loader']
+				use: ['vue-style-loader', 'css-loader', {
+					loader: 'sass-loader',
+					options: {
+						data: '$scope_version: ' + SCOPE_VERSION + ';'
+					}
+				}]
 			},
 			{
 				test: /\.(js|vue)$/,
@@ -60,9 +67,7 @@ module.exports = {
 	plugins: [
 		new VueLoaderPlugin(),
 		new StyleLintPlugin(),
-		new DefinePlugin({
-			SCOPE_VERSION: JSON.stringify(md5(version))
-		})
+		new DefinePlugin({SCOPE_VERSION})
 	],
 	resolve: {
 		alias: {


### PR DESCRIPTION
Fix #30 
``` js
/**
 * Manually scope a vue component to be used with an external css file
 * The external css must have the root element set with [data-v-#{$scope_version}]
 * 
 * e.g. .multiselect[data-v-#{$scope_version}]
 * import ScopeComponent from 'Utils/ScopeComponent'
 * import Multiselect from 'vue-multiselect'
 * import './index.scss'
 * ScopeComponent(Multiselect)
 * 
 * @param {Object} Component the vue component
 */
```