### PR TITLE
Adding avatar updates after user change and group support

### DIFF
--- a/src/components/Avatar/Avatar.vue
+++ b/src/components/Avatar/Avatar.vue
@@ -102,7 +102,7 @@ export default {
 		},
 		/**
 		 * Declares username is not a user's name, when true.
-		 * Prevents loading user's avatar from server and forces generating colored initials, 
+		 * Prevents loading user's avatar from server and forces generating colored initials,
 		 * i.e. if the user is a group
 		 */
 		isNoUser: {

--- a/src/components/Avatar/Avatar.vue
+++ b/src/components/Avatar/Avatar.vue
@@ -101,7 +101,9 @@ export default {
 			default: false
 		},
 		/**
-		 * Define username is not a user name
+		 * Declares username is not a user's name, when true.
+		 * Prevents loading user's avatar from server and forces generating colored initials, 
+		 * i.e. if the user is a group
 		 */
 		isNoUser: {
 			type: Boolean,

--- a/src/components/Avatar/Avatar.vue
+++ b/src/components/Avatar/Avatar.vue
@@ -99,6 +99,13 @@ export default {
 		disableTooltip: {
 			type: Boolean,
 			default: false
+		},
+		/**
+		 * Define username is not a user name
+		 */
+		isNoUser: {
+			type: Boolean,
+			default: false
 		}
 	},
 	data() {
@@ -171,38 +178,14 @@ export default {
 			})
 		}
 	},
+	watch: {
+		user() {
+			this.userDoesNotExist = false
+			this.loadAvatarUrl()
+		}
+	},
 	mounted() {
-		/** Only run avatar image loading if either user or url property is defined */
-		if (!this.isUrlDefined && !this.isUserDefined) {
-			this.loadingState = false
-			this.userDoesNotExist = true
-			return
-		}
-
-		let avatarUrl = OC.generateUrl(
-			'/avatar/{user}/{size}',
-			{
-				user: this.user,
-				size: Math.ceil(this.size * window.devicePixelRatio)
-			})
-		// eslint-disable-next-line camelcase
-		if (this.user === OC.getCurrentUser().uid && typeof oc_userconfig !== 'undefined') {
-			avatarUrl += '?v=' + oc_userconfig.avatar.version
-		}
-		if (this.isUrlDefined) {
-			avatarUrl = this.url
-		}
-
-		let img = new Image()
-		img.onload = () => {
-			this.avatarUrlLoaded = avatarUrl
-			this.loadingState = false
-		}
-		img.onerror = () => {
-			this.userDoesNotExist = true
-			this.loadingState = false
-		}
-		img.src = avatarUrl
+		this.loadAvatarUrl()
 	},
 	methods: {
 		toggleMenu() {
@@ -223,6 +206,39 @@ export default {
 			}).catch(() => {
 				this.contactsMenuOpenState = false
 			})
+		},
+		loadAvatarUrl() {
+			/** Only run avatar image loading if either user or url property is defined */
+			if (!this.isUrlDefined && (!this.isUserDefined || this.isNoUser)) {
+				this.loadingState = false
+				this.userDoesNotExist = true
+				return
+			}
+
+			let avatarUrl = OC.generateUrl(
+				'/avatar/{user}/{size}',
+				{
+					user: this.user,
+					size: Math.ceil(this.size * window.devicePixelRatio)
+				})
+			// eslint-disable-next-line camelcase
+			if (this.user === OC.getCurrentUser().uid && typeof oc_userconfig !== 'undefined') {
+				avatarUrl += '?v=' + oc_userconfig.avatar.version
+			}
+			if (this.isUrlDefined) {
+				avatarUrl = this.url
+			}
+
+			let img = new Image()
+			img.onload = () => {
+				this.avatarUrlLoaded = avatarUrl
+				this.loadingState = false
+			}
+			img.onerror = () => {
+				this.userDoesNotExist = true
+				this.loadingState = false
+			}
+			img.src = avatarUrl
 		}
 	}
 }


### PR DESCRIPTION
New try: 
I had some problems because the user of a user row was loaded asynchronous after the mounting of Avatar and so the avatar didn't get updated. Adding a watch to the username and moving the code from the mounted to a method did the job.

Additionally I got some problems, when creating an avatar for a group, which name was identically to a user's name. I added a prop to declare the user name ist not regarding a user.

I hope, I found a right way to solve the problems.