### PR TITLE
Wrap Multiselect

### DIFF
--- a/src/components/Multiselect/AvatarSelectOption.vue
+++ b/src/components/Multiselect/AvatarSelectOption.vue
@@ -1,0 +1,77 @@
+<template>
+	<span class="option">
+		<avatar :display-name="option.displayName" :user="option.user" :disable-tooltip="true"
+			class="option__avatar" />
+		<div class="option__desc">
+			<span class="option__desc--lineone">{{ option.displayName }}</span>
+			<span v-if="option.desc" class="option__desc--linetwo">{{ option.desc }}</span>
+		</div>
+		<span v-if="option.icon" class="icon option__icon" :class="option.icon"
+			title="Test0" />
+	</span>
+</template>
+
+<script>
+import Avatar from 'Components/Avatar'
+
+export default {
+	name: 'AvatarSelectOption',
+	components: {
+		Avatar
+	},
+	props: {
+		option: {
+			type: Object,
+			default() {
+				return {
+					desc: '',
+					displayName: 'Admin',
+					icon: 'icon-user',
+					user: 'admin'
+				}
+			},
+			validator: (option) => {
+				// minimum required is displayName
+				return 'displayName' in option
+			}
+		}
+	}
+}
+</script>
+
+<style lang="scss" scoped>
+.option {
+	display: flex;
+	align-items: center;
+	height: 32px;
+	width: 100%;
+	&__avatar {
+		flex: 0 0 32px;
+		width: 32px;
+		height: 32px;
+		margin-right: 6px;
+	}
+	&__desc {
+		display: flex;
+		flex-direction: column;
+		justify-content: center;
+		flex: 1 1;
+		&--lineone {
+			color: var(--color-text-light);
+			&--highlight {
+				font-weight: 600;
+			}
+		}
+		&--linetwo {
+			opacity: .7;
+		}
+	}
+	&__icon {
+		width: 44px;
+		height: 44px;
+		flex: 0 0 44px;
+		margin: -6px;
+		opacity: .5;
+	}
+}
+</style>

--- a/src/components/Multiselect/Multiselect.vue
+++ b/src/components/Multiselect/Multiselect.vue
@@ -1,0 +1,206 @@
+<!--
+  - @copyright Copyright (c) 2018 Julius Härtl <jus@bitgrid.net>
+  -
+  - @author Julius Härtl <jus@bitgrid.net>
+  -
+  - @license GNU AGPL version 3 or any later version
+  -
+  - This program is free software: you can redistribute it and/or modify
+  - it under the terms of the GNU Affero General Public License as
+  - published by the Free Software Foundation, either version 3 of the
+  - License, or (at your option) any later version.
+  -
+  - This program is distributed in the hope that it will be useful,
+  - but WITHOUT ANY WARRANTY; without even the implied warranty of
+  - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  - GNU Affero General Public License for more details.
+  -
+  - You should have received a copy of the GNU Affero General Public License
+  - along with this program. If not, see <http://www.gnu.org/licenses/>.
+  -
+  -->
+
+<template>
+	<!--
+	# This is the original Multiselect !
+	## tag-placeholder="create"
+	-> Hack to allow us to detect when an option needs
+	-  to be created (with css) and apply the proper
+	-  styling to this entry, @see [data-select='create']
+	## :close-on-select="!multiple"
+	-> If multiple choice allowed, leave the dropdown
+	-  open after select
+	## v-on="$listeners", v-bind="$attrs"
+	-> Forward all undeclared props to the vue-multiselect child
+	-->
+	<vue-multiselect
+		:value="value"
+		v-bind="$attrs"
+		class="multiselect-vue"
+		:limit="maxOptions"
+		:close-on-select="!multiple"
+		:multiple="multiple"
+		:label="label"
+		:track-by="trackBy"
+		tag-placeholder="create"
+		v-on="$listeners"
+		@update:value="$emit('update:value', value)">
+		<template v-if="userSelect" slot="option" slot-scope="{ option }">
+			<avatar-select-option :option="option" />
+		</template>
+		<span slot="limit" v-tooltip.auto="formatLimitTitle(value)" class="multiselect__limit">
+			{{ limitString }}
+		</span>
+		<!-- TODO add translation system
+		<span slot="noResult">{{ t('core', 'No results') }}</span> -->
+	</vue-multiselect>
+</template>
+
+<script>
+import VueMultiselect from 'vue-multiselect'
+import { VTooltip } from 'v-tooltip'
+import AvatarSelectOption from './AvatarSelectOption'
+
+export default {
+	name: 'Multiselect',
+	components: {
+		VueMultiselect,
+		AvatarSelectOption
+	},
+	directives: {
+		tooltip: VTooltip
+	},
+	inheritAttrs: false,
+	/**
+	 * Every prop that is defined here will break the auto
+	 * forward to the vue-multiselect component
+	 * You will have to specify it as a prop on the template
+	 */
+	props: {
+		// eslint-disable-next-line
+		value: {
+			default() {
+				return []
+			}
+		},
+		// you need to declare props here if you want
+		// to use them on this component
+		// otherwise they're just sent to the child
+		// component and are not accessible here
+		multiple: {
+			type: Boolean,
+			default: false
+		},
+		limit: {
+			type: Number,
+			default: 99999
+		},
+		// eslint-disable-next-line
+		label: {
+			type: String
+		},
+		// eslint-disable-next-line
+		trackBy: {
+			type: String
+		},
+		/**
+		 * Enable the big user selector w/ avatar
+		 * Make sure your objects fit the requirements
+		 * @default true
+		 * @type {Boolean}
+		 */
+		userSelect: {
+			type: Boolean,
+			default: false
+		},
+		/**
+		 * Enable the automatic limit and width calculation
+		 * Only works on multiple
+		 * @default true
+		 * @type {Boolean}
+		 */
+		autoLimit: {
+			type: Boolean,
+			default: true
+		},
+		/**
+		* If autoLimit, allow to specify the min-width of every
+		* selected option when calculating the number of options
+		* to show. This needs to be a positive integer.
+		* @default 150
+		* @type {Number}
+		*/
+		tagWidth: {
+			type: Number,
+			default: 150,
+			validator: (value) => {
+				return value > 0
+			}
+		}
+	},
+	data() {
+		return {
+			elWidth: 0
+		}
+	},
+	computed: {
+		/**
+		 * Calculate the number of options to show
+		 * depending on the width of the select.
+		 * Only works if `autoLimit` is `true`
+		 */
+		maxOptions() {
+			if (this.autoLimit && this.elWidth > 0 && this.tagWidth !== 0) {
+				const limit = Math.floor(this.elWidth / this.tagWidth)
+				return limit > 0 ? limit : 1
+			}
+			return this.limit ? this.limit : 9999
+		},
+		/**
+		 * Make the tooltip limit string for the `autoLimit`
+		 */
+		limitString() {
+			return `+${this.value.length - this.maxOptions}`
+		}
+	},
+	watch: {
+		// ensure we update the width when we add or remove data
+		value: function() {
+			this.updateWidth()
+		}
+	},
+	mounted() {
+		this.updateWidth()
+		window.addEventListener('resize', this.updateWidth)
+	},
+	beforeDestroy() {
+		window.removeEventListener('resize', this.updateWidth)
+	},
+	methods: {
+		/**
+		 * Format array of groups objects to a string
+		 * for the limit popup using the label prop
+		 *
+		 * @param {array} options The selected options
+		 * @returns {string}
+		 */
+		formatLimitTitle(options) {
+			if (options && options.length > 0) {
+				let selection = options
+				if (typeof options[0] === 'object') {
+					selection = options.map(option => option[this.label])
+				}
+				return selection.slice(this.maxOptions).join(', ')
+			}
+			return ''
+		},
+		/**
+		 * Update the component width data
+		 */
+		updateWidth() {
+			// width of the tags wrapper minus the padding
+			this.elWidth = this.$el.querySelector('.multiselect__tags-wrap').offsetWidth - 10
+		}
+	}
+}
+</script>

--- a/src/components/Multiselect/index.js
+++ b/src/components/Multiselect/index.js
@@ -20,7 +20,7 @@
  *
  */
 import ScopeComponent from 'Utils/ScopeComponent'
-import Multiselect from 'vue-multiselect'
+import Multiselect from './Multiselect'
 import './index.scss'
 
 ScopeComponent(Multiselect)

--- a/src/components/Multiselect/index.scss
+++ b/src/components/Multiselect/index.scss
@@ -1,3 +1,6 @@
+// scoping is not working inside the Multiselect.vue component
+// as the nested properties are not inside it
+// Therefore we need to use an external scoping
 .multiselect[data-v-#{$scope_version}] {
 	margin: 1px 2px;
 	padding: 0 !important;
@@ -37,7 +40,7 @@
 			padding: 3px $space-between;
 			flex-grow: 1;
 			/* no tags or simple select? Show input directly
-			   input is used to display single value */
+			input is used to display single value */
 			&:empty ~ input.multiselect__input {
 				opacity: 1 !important;
 				/* hide default empty text, show input instead */
@@ -57,13 +60,13 @@
 				align-items: center;
 				border-radius: 3px;
 				/* require to override the default width
-				   and force the tag to shring properly */
+				and force the tag to shring properly */
 				min-width: 0;
 				max-width: 50%;
 				max-width: fit-content;
 				max-width: -moz-fit-content;
 				/* css hack, detect if more than two tags
-				   if so, flex-basis is set to half */
+				if so, flex-basis is set to half */
 				&:only-child {
 					flex: 0 1 auto;
 				}
@@ -71,7 +74,7 @@
 					margin-right: $space-between;
 				}
 				/* ellipsis the groups to be sure
-				   we display at least two of them */
+				we display at least two of them */
 				> span {
 					white-space: nowrap;
 					text-overflow: ellipsis;
@@ -144,8 +147,8 @@
 				white-space: nowrap;
 				overflow: hidden;
 				text-overflow: ellipsis;
-				height: 20px;
 				margin: 0;
+				height: auto;
 				min-height: 1em;
 				-webkit-touch-callout: none;
 				-webkit-user-select: none;
@@ -175,8 +178,7 @@
 					opacity: .5;
 				}
 				/* add the prop tag-placeholder="create" to add the +
-				 * icon on top of an unknown-and-ready-to-be-created entry
-				 */
+				icon on top of an unknown-and-ready-to-be-created entry */
 				&[data-select='create'] {
 					&::before {
 						background-image: var(--icon-add-000);


### PR DESCRIPTION
After #70 
Fix #91
- [x] Create options standards for Multiselect
- [x] Slots
- [x] Style fixes

### Examples
Default style
``` html
<Multiselect :options="options" v-model="select" />
```
Default style multiple with auto width calculation (default option width is 150px)
You can set the min with `:tag-width="80"`
``` html
<Multiselect :options="options" v-model="select" :multiple="true" />`
```
Disable auto width calculation (always show max XXX entries)
``` html
<Multiselect :options="options" v-model="select" :multiple="true" :auto-limit="false" :limit="XXX" />`
```
Avatar select option
``` html
<Multiselect :options="options" v-model="select" label="displayName" track-by="user" :multiple="true" :user-select="true" />`
```

![capture d ecran_2018-11-08_16-36-37](https://user-images.githubusercontent.com/14975046/48209967-b8bf7000-e376-11e8-81f6-22f2f4dd967e.png)
