### PR TITLE
Fix default items for app navigation

### DIFF
--- a/src/components/AppNavigation/AppNavigation.vue
+++ b/src/components/AppNavigation/AppNavigation.vue
@@ -67,12 +67,7 @@ export default {
 						icon: 'icon-add',
 						text: 'New item'
 					},
-					menu: {
-						id: 'navigation',
-						items: [
-
-						]
-					}
+					items: []
 				}
 			}
 		}


### PR DESCRIPTION
Just see the template, the default has a (wrong? outdated?) structure.