### PR TITLE
React to avatar URL changes

### DIFF
--- a/src/components/Avatar/Avatar.vue
+++ b/src/components/Avatar/Avatar.vue
@@ -181,6 +181,10 @@ export default {
 		}
 	},
 	watch: {
+		url() {
+			this.userDoesNotExist = false
+			this.loadAvatarUrl()
+		},
 		user() {
 			this.userDoesNotExist = false
 			this.loadAvatarUrl()


### PR DESCRIPTION
Discovered working on https://github.com/nextcloud/mail/projects/4#card-14518419. In Mail we don't know the URL right away but first have to check if there is an avatar URL for the email asynchronously, hence the URL prop gets set later on. Without this patch, the avatar was always rendered for a user that does not exist.