### PR TITLE
Fix propagation of handled click event in action component

### DIFF
--- a/src/components/Action/Action.vue
+++ b/src/components/Action/Action.vue
@@ -30,7 +30,7 @@
 		<!-- If more than one action, create a popovermenu -->
 		<template v-if="!isSingleAction">
 			<div v-click-outside="closeMenu" tabindex="1" class="action-item__menutoggle icon-more"
-				@click="toggleMenu" />
+				@click.prevent="toggleMenu" />
 			<div :class="{ 'open': opened }" class="action-item__menu popovermenu">
 				<popover-menu :menu="actions" />
 			</div>


### PR DESCRIPTION
This makes it possible to use the action component in the content list
without triggering the underlying router link handler.

Any other event handlers that rely on the propagated event still work this way.