### PR TITLE
PopoverMenu: Allow having longtext besides text item property

### DIFF
--- a/src/components/PopoverMenu/PopoverMenuItem.vue
+++ b/src/components/PopoverMenu/PopoverMenuItem.vue
@@ -28,7 +28,11 @@
 			rel="noreferrer noopener" @click="action">
 			<span v-if="!iconIsUrl" :class="item.icon" />
 			<img v-else :src="item.icon">
-			<span v-if="item.text">{{ item.text }}</span>
+			<p v-if="item.text && item.longtext">
+				<strong class="menuitem-text">{{ item.text }}</strong><br>
+				<span class="menuitem-text-detail">{{ item.longtext }}</span>
+			</p>
+			<span v-else-if="item.text">{{ item.text }}</span>
 			<p v-else-if="item.longtext">{{ item.longtext }}</p>
 		</a>
 
@@ -54,20 +58,35 @@
 		</span>
 
 		<!-- If item.action is set instead, a button will be used -->
-		<button v-else-if="item.action" @click.stop.prevent="item.action">
+		<button v-else-if="item.action" class="menuitem" @click.stop.prevent="item.action">
 			<span :class="item.icon" />
-			<span v-if="item.text">{{ item.text }}</span>
+			<p v-if="item.text && item.longtext">
+				<strong class="menuitem-text">{{ item.text }}</strong><br>
+				<span class="menuitem-text-detail">{{ item.longtext }}</span>
+			</p>
+			<span v-else-if="item.text">{{ item.text }}</span>
 			<p v-else-if="item.longtext">{{ item.longtext }}</p>
 		</button>
 
 		<!-- If item.longtext is set AND the item does not have an action -->
 		<span v-else class="menuitem">
 			<span :class="item.icon" />
-			<span v-if="item.text">{{ item.text }}</span>
+			<p v-if="item.text && item.longtext">
+				<strong class="menuitem-text">{{ item.text }}</strong><br>
+				<span class="menuitem-text-detail">{{ item.longtext }}</span>
+			</p>
+			<span v-else-if="item.text">{{ item.text }}</span>
 			<p v-else-if="item.longtext">{{ item.longtext }}</p>
+
 		</span>
 	</li>
 </template>
+
+<style scoped>
+	button.menuitem {
+		text-align: left;
+	}
+</style>
 
 <script>
 export default {


### PR DESCRIPTION
This PR adds support for having an longtext and text property set besides each other in a popovermenu item.

![image](https://user-images.githubusercontent.com/3404133/48834090-2dce7480-ed7d-11e8-9ebf-3db60b4d6d83.png)
